### PR TITLE
BUG: editor set to 'display: none' when viewing saved rants [Resolved]

### DIFF
--- a/frontend/components/rant-list.js
+++ b/frontend/components/rant-list.js
@@ -39,7 +39,7 @@ Tonic.add(class RantList extends Tonic {
       setMode(true)
     } else if (r.state === 'signed') {
       const pickle = await kernel.pickle(id)
-      navigate(`r/${pickle}`)
+      navigate(`show/${pickle}`)
     }
   }
 

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -108,7 +108,7 @@ async function main () {
     } else {
       const id = await kernel.commit()
       const pickle = await kernel.pickle(id)
-      navigate(`r/${pickle}`)
+      navigate(`show/${pickle}`)
       setMode(false)
       console.log('Comitted', id.toString('hex')) // , get(kernel.$rant()))
     }


### PR DESCRIPTION
Resolved by changing route `#r/` to `#show/`


The CSS issue
---

> in [_`global.css`_](https://github.com/telamon/rant/blob/0afee58a3be89e8d4b252d3c3cdb852b92aca57f/pub/global.css#L154) this line will set editor to ` display: none; ` if the `data-view` attribute is neither `edit` or `show`.
> ```css
> main:not([data-view=edit]):not([data-view=show]) editor { display: none; }
> ```
> in this case we routed to `#r/` which sets the `data-view` attribute to `r` and results in the display property being `none`



The API issue
---

>  in [_`api.js`_](https://github.com/telamon/rant/blob/0afee58a3be89e8d4b252d3c3cdb852b92aca57f/frontend/api.js#L27) this line will set the mode depending on the current route..
> ```js
> if (!['pitch', 'show', 'edit'].find(p => p === page)) return true
> ```
> When we routed to `#r/` this line would not execute and the function would return the input parameter. As a result the mode would remain unchanged and nothing would happen if we clicked the `#btn-toggle` button in [_`render-ctrls.js`_](https://github.com/telamon/rant/blob/0afee58a3be89e8d4b252d3c3cdb852b92aca57f/frontend/components/render-ctrls.js#L12)
